### PR TITLE
Fix symbol error messages of represented models showing missing translation

### DIFF
--- a/lib/granite/form/model/representation.rb
+++ b/lib/granite/form/model/representation.rb
@@ -79,7 +79,7 @@ module Granite
             errors.where(from).each do |error|
               options = error.options
               # If we generate message for built-in validation, we don't want to later escape it in our monkey-patch
-              options = options.merge(message: error.message.html_safe) unless options.key?(:message)
+              options = options.merge(message: error.message.html_safe)
 
               errors.add(to, error.type, **options)
             end

--- a/spec/lib/granite/form/model/representation_spec.rb
+++ b/spec/lib/granite/form/model/representation_spec.rb
@@ -126,13 +126,25 @@ describe Granite::Form::Model::Representation do
 
     specify do
       expect { post.validate }.to change { post.errors.messages }
-        .to(hash_including('author.user.email': ['is invalid'], name: ["can't be blank"]))
+        .to('author.user.email': ['is invalid'], name: ["can't be blank"])
     end
 
     if ActiveModel.version >= Gem::Version.new('6.1.0')
       specify do
         expect { post.validate }.to change { post.errors.details }
-          .to(hash_including('author.user.email': [{error: 'is invalid'}], name: [{error: :blank}]))
+          .to('author.user.email': [{error: 'is invalid'}], name: [{error: :blank}])
+      end
+    end
+
+    context 'when using symbol in error message of represented model' do
+      before do
+        Author.validates :name, inclusion: {in: ['Author'], message: :invalid_name, allow_blank: true}
+        post.author.name = 'Not Author'
+      end
+
+      specify do
+        expect { post.validate }.to change { post.errors.messages }
+          .to('author.user.email': ['is invalid'], name: ['must be Author'])
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,7 @@ require 'rack/test'
 require 'action_controller/metal/strong_parameters'
 require 'database_cleaner'
 
-require 'support/model_helpers'
-require 'support/muffle_helper'
+Dir[File.join(__dir__, 'support', '**', '*.rb')].sort.each { |f| require f }
 
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
 ActiveRecord::Base.logger = Logger.new('/dev/null')

--- a/spec/support/translations.rb
+++ b/spec/support/translations.rb
@@ -1,0 +1,6 @@
+I18n.backend.store_translations(:en, YAML.safe_load(<<-YAML))
+  activerecord:
+    errors:
+      messages:
+        invalid_name: "must be Author"
+YAML


### PR DESCRIPTION
If represented model has `message: :some_symbol`, then `options.key?(:message)` returns true. This adds a message to outer model with `message: :some_symbol`. The outer model though will not have a translation key and thus we'll get a missing translation.