### PR TITLE
Initialize attributes with reflection

### DIFF
--- a/lib/granite/form/model/attributes/base.rb
+++ b/lib/granite/form/model/attributes/base.rb
@@ -3,17 +3,13 @@ module Granite
     module Model
       module Attributes
         class Base
-          attr_reader :name, :owner
-          delegate :type, :typecaster, :readonly, to: :reflection
+          attr_reader :reflection, :owner
+          delegate :name, :type, :typecaster, :readonly, to: :reflection
 
-          def initialize(name, owner)
-            @name = name
+          def initialize(reflection, owner)
+            @reflection = reflection
             @owner = owner
             @origin = :default
-          end
-
-          def reflection
-            @owner.class._attributes[name]
           end
 
           def write_value(value, origin: :user)

--- a/lib/granite/form/model/attributes/reflections/base.rb
+++ b/lib/granite/form/model/attributes/reflections/base.rb
@@ -27,7 +27,7 @@ module Granite
             end
 
             def build_attribute(owner, raw_value = Granite::Form::UNDEFINED)
-              attribute = self.class.attribute_class.new(name, owner)
+              attribute = self.class.attribute_class.new(self, owner)
               attribute.write_value(raw_value, origin: :persistence) unless raw_value == Granite::Form::UNDEFINED
               attribute
             end

--- a/spec/granite/form/model/attributes/localized_spec.rb
+++ b/spec/granite/form/model/attributes/localized_spec.rb
@@ -6,7 +6,7 @@ describe Granite::Form::Model::Attributes::Localized do
   def attribute(*args)
     options = args.extract_options!
     Dummy.add_attribute(Granite::Form::Model::Attributes::Reflections::Localized, :field, options)
-    described_class.new('field', Dummy.new)
+    Dummy.new.attribute(:field)
   end
 
   describe '#read' do


### PR DESCRIPTION
Attributes already have access to their reflection (configuration of the attribute). But they do it in a weird way, they go through `owner` to fetch the reflection each time they need it. This isn't needed and adds more dependency on knowing `owner` internals, while in reality they could get the reflection when said reflection is initializing the attribute.