### PR TITLE
Fix duplicated errors if validated twice

### DIFF
--- a/lib/granite/form/model/validations/nested.rb
+++ b/lib/granite/form/model/validations/nested.rb
@@ -19,7 +19,7 @@ module Granite
             def self.import_errors(from, to, prefix)
               from.each do |error|
                 key = "#{prefix}.#{error.attribute}"
-                to.import(error, attribute: key) unless to.added?(key, error.type, error.options)
+                to.import(error, attribute: key) unless to.messages_for(key).include?(error.message)
               end
             end
           else

--- a/spec/granite/form/model/validations/nested_spec.rb
+++ b/spec/granite/form/model/validations/nested_spec.rb
@@ -143,6 +143,106 @@ describe Granite::Form::Model::Validations::NestedValidator do
       it do
         expect { subject.valid? }.not_to raise_error
         expect(subject).not_to be_valid
+        expect(subject.errors.count).to eq(1)
+      end
+    end
+  end
+
+  context 'object field is invalid and has representation of that field' do
+    before do
+      stub_class(:validated_object) do
+        include Granite::Form::Model::Validations
+        include Granite::Form::Model::Attributes
+        include Granite::Form::Model::Primary
+
+        primary :id
+        attribute :title, String
+        validates_presence_of :title
+      end
+
+      Main.class_eval do
+        include Granite::Form::Model::Associations
+        include Granite::Form::Model::Representation
+        represents :title, of: :object
+        attribute :object, Object
+        validates :object, nested: true
+      end
+
+      Main.class_eval do
+        include Granite::Form::Model::Representation
+        represents :title, of: :object
+      end
+    end
+
+    subject(:instance) { Main.instantiate name: 'hello', object: object }
+
+    context do
+      let(:object) { ValidatedObject.new(title: 'Mr.') }
+      it { is_expected.to be_valid }
+    end
+
+    context do
+      let(:object) { ValidatedObject.new }
+      it do
+        expect { subject.valid? }.not_to raise_error
+        expect(subject).not_to be_valid
+        expect(subject.errors.count).to eq(1)
+      end
+    end
+
+    context 'validation has condition' do
+      before do
+        stub_class(:validated_object) do
+          include Granite::Form::Model::Validations
+          include Granite::Form::Model::Attributes
+          include Granite::Form::Model::Primary
+
+          primary :id
+          attribute :title, String
+          validates_presence_of :title, if: -> { true }
+        end
+      end
+
+      context do
+        let(:object) { ValidatedObject.new(title: 'Mr.') }
+        it { is_expected.to be_valid }
+      end
+
+      context do
+        let(:object) { ValidatedObject.new }
+        it do
+          expect { subject.valid? }.not_to raise_error
+          expect(subject).not_to be_valid
+          expect(subject.errors.count).to eq(1)
+        end
+      end
+    end
+
+    context 'validation has message' do
+      before do
+        stub_class(:validated_object) do
+          include Granite::Form::Model::Validations
+          include Granite::Form::Model::Attributes
+          include Granite::Form::Model::Primary
+
+          primary :id
+          attribute :title, String
+          validates_presence_of :title, message: 'test message'
+        end
+      end
+
+      context do
+        let(:object) { ValidatedObject.new(title: 'Mr.') }
+        it { is_expected.to be_valid }
+      end
+
+      context do
+        let(:object) { ValidatedObject.new }
+        it do
+          expect { subject.valid? }.not_to raise_error
+          expect(subject).not_to be_valid
+          expect(subject.errors.count).to eq(1)
+        end
       end
     end
   end


### PR DESCRIPTION
### Description
 If subject has `represents %field%, of: %subject%` and `validates %subject%, nested: true` validations will be run twice. `to.added?(key, error.type, error.options)` at https://github.com/toptal/granite-form/blob/4a40c89e95eb5d26d83937ec164b9b6e8ecd7910/lib/granite/form/model/validations/nested.rb#L22 should prevent errors to be added twice, however `added?` implemented that way that it ignores some options, e.g. `message`, on one side of comparison only which causes errors not being recognized as already added.
 See https://github.com/rails/rails/blob/6-1-stable/activemodel/lib/active_model/errors.rb#L439
 and therefore https://github.com/rails/rails/blob/6-1-stable/activemodel/lib/active_model/error.rb#L186
 
 This is probably a bug in Rails or `added?` misuse, I'm not sure yet and have to confirm it later. Anyway to properly check if error was already added we have to options:
 1. Remove ignored options from the other side of comparison
 ```ruby
options = error.options.except(*::ActiveModel::Error::CALLBACKS_OPTIONS + ::ActiveModel::Error::MESSAGE_OPTIONS)
to.import(error, attribute: key) unless to.added?(key, error.type, options)
 ```
 2. Compare by message
 ```ruby
 to.import(error, attribute: key) unless to.messages_for(key).include?(error.message)
 ```
 I tend to second option as it doesn't depend on several interfaces such as `CALLBACKS_OPTIONS` and `MESSAGE_OPTIONS` constants.
 
### How to test
- CI is green
- Remove changes in `lib/granite/form/model/validations/nested.rb` locally and run `bundle exec rspec`, couple of specs should fail as they expect to be only 1 instance of error to be added to subject.
 