### PR TITLE
Refactor reflections initialization

### DIFF
--- a/lib/granite/form/model/attributes/reflections/attribute.rb
+++ b/lib/granite/form/model/attributes/reflections/attribute.rb
@@ -4,12 +4,6 @@ module Granite
       module Attributes
         module Reflections
           class Attribute < Base
-            def self.build(target, generated_methods, name, *args, &block)
-              attribute = super(target, generated_methods, name, *args, &block)
-              generate_methods name, generated_methods
-              attribute
-            end
-
             def self.generate_methods(name, target)
               target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{name}

--- a/lib/granite/form/model/attributes/reflections/base.rb
+++ b/lib/granite/form/model/attributes/reflections/base.rb
@@ -7,11 +7,9 @@ module Granite
             attr_reader :name, :options
 
             class << self
-              def build(_target, _generated_methods, name, *args, &block)
-                options = args.extract_options!
-                options[:type] = args.first if args.first
-                options[:default] = block if block
-                new(name, options)
+              def build(_target, generated_methods, name, *args, &block)
+                generate_methods name, generated_methods
+                new(name, *args, &block)
               end
 
               def generate_methods(name, target) end
@@ -21,9 +19,12 @@ module Granite
               end
             end
 
-            def initialize(name, options = {})
+            def initialize(name, *args, &block)
               @name = name.to_s
-              @options = options
+
+              @options = args.extract_options!
+              @options[:type] = args.first if args.first
+              @options[:default] = block if block
             end
 
             def build_attribute(owner, raw_value = Granite::Form::UNDEFINED)

--- a/lib/granite/form/model/attributes/reflections/reference_one.rb
+++ b/lib/granite/form/model/attributes/reflections/reference_one.rb
@@ -4,12 +4,6 @@ module Granite
       module Attributes
         module Reflections
           class ReferenceOne < Base
-            def self.build(_target, generated_methods, name, *args)
-              options = args.extract_options!
-              generate_methods name, generated_methods
-              new(name, options)
-            end
-
             def self.generate_methods(name, target)
               target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def #{name}


### PR DESCRIPTION
* Remove duplicate code from reflections
* Move options parsing to initialize, so that `build` means generate method & initialize