### PR TITLE
[ROGUE-3519] Add scope method for association for AR compatibility

### DIFF
--- a/lib/granite/form/model/associations/reflections/base.rb
+++ b/lib/granite/form/model/associations/reflections/base.rb
@@ -56,6 +56,9 @@ module Granite
               false
             end
 
+            # AR compatibility for preloading models within ar_lazy_preload
+            def scope; end
+
             def build_association(object)
               self.class.association_class.new object, self
             end

--- a/lib/granite/form/version.rb
+++ b/lib/granite/form/version.rb
@@ -1,5 +1,5 @@
 module Granite
   module Form
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.3.1'.freeze
   end
 end


### PR DESCRIPTION
The new version of the [ar_lazy_preload](https://github.com/DmitryTsepelev/ar_lazy_preload/blob/master/lib/ar_lazy_preload/contexts/base_context.rb#L94) gem uses the scope method on the reflections to be able to preload associations properly. This PR adds scope that returns nil to be compatible with it. 

Full description of the problem be found here https://toptal-core.atlassian.net/browse/COR-1029