### PR TITLE
Extract enum & enumerize to type_definition

### DIFF
--- a/lib/granite/form/model/associations/nested_attributes.rb
+++ b/lib/granite/form/model/associations/nested_attributes.rb
@@ -74,7 +74,7 @@ module Granite
               primary_attribute_name = primary_name_for(association.reflection.klass)
               if existing_record
                 primary_attribute = existing_record.attribute(primary_attribute_name)
-                primary_attribute_value = primary_attribute.type_definition.ensure_type(attributes[primary_attribute_name]) if primary_attribute
+                primary_attribute_value = primary_attribute.type_definition.prepare(attributes[primary_attribute_name]) if primary_attribute
               end
 
               if existing_record && (!primary_attribute || options[:update_only] || existing_record.primary_attribute == primary_attribute_value)
@@ -124,7 +124,7 @@ module Granite
                 else
                   existing_record = association.target.detect do |record|
                     primary_attribute_value = record.attribute(primary_attribute_name)
-                      .type_definition.ensure_type(attributes[primary_attribute_name])
+                      .type_definition.prepare(attributes[primary_attribute_name])
                     record.primary_attribute == primary_attribute_value
                   end
                   if existing_record

--- a/lib/granite/form/model/attributes/attribute.rb
+++ b/lib/granite/form/model/attributes/attribute.rb
@@ -14,7 +14,7 @@ module Granite
 
           def read
             variable_cache(:value) do
-              normalize(enumerize(type_definition.ensure_type(read_before_type_cast)))
+              normalize(type_definition.prepare(read_before_type_cast))
             end
           end
 
@@ -30,24 +30,6 @@ module Granite
 
           def defaultize(value, default_value = nil)
             !defaultizer.nil? && value.nil? ? default_value || default : value
-          end
-
-          def enum
-            source = owner.evaluate(enumerizer)
-
-            case source
-            when Range
-              source.to_a
-            when Set
-              source
-            else
-              Array.wrap(source)
-            end.to_set
-          end
-
-          def enumerize(value)
-            set = enum if enumerizer
-            value if !set || (set.none? || set.include?(value))
           end
 
           def normalize(value)

--- a/lib/granite/form/model/attributes/base.rb
+++ b/lib/granite/form/model/attributes/base.rb
@@ -4,7 +4,7 @@ module Granite
       module Attributes
         class Base
           attr_reader :type_definition
-          delegate :type, :reflection, :owner, to: :type_definition
+          delegate :type, :reflection, :owner, :enum, to: :type_definition
           delegate :name, :readonly, to: :reflection
 
           def initialize(type_definition)

--- a/lib/granite/form/model/attributes/collection.rb
+++ b/lib/granite/form/model/attributes/collection.rb
@@ -4,9 +4,7 @@ module Granite
       module Attributes
         class Collection < Attribute
           def read
-            @value ||= normalize(read_before_type_cast.map do |value|
-              enumerize(type_definition.ensure_type(value))
-            end)
+            @value ||= normalize(read_before_type_cast.map { |value| type_definition.prepare(value) })
           end
 
           def read_before_type_cast

--- a/lib/granite/form/model/attributes/dictionary.rb
+++ b/lib/granite/form/model/attributes/dictionary.rb
@@ -9,10 +9,8 @@ module Granite
             @value ||= begin
                          hash = read_before_type_cast
                          hash = hash.stringify_keys.slice(*keys) if keys.present?
-
-                         normalize(Hash[hash.map do |key, value|
-                           [key, enumerize(type_definition.ensure_type(value))]
-                         end].with_indifferent_access).with_indifferent_access
+                         hash = Hash[hash.map { |key, value| [key, type_definition.prepare(value)] }]
+                         normalize(hash.with_indifferent_access).with_indifferent_access
                        end
           end
 

--- a/lib/granite/form/model/attributes/reference_many.rb
+++ b/lib/granite/form/model/attributes/reference_many.rb
@@ -5,7 +5,7 @@ module Granite
         class ReferenceMany < ReferenceOne
           def type_casted_value
             variable_cache(:value) do
-              read_before_type_cast.map { |id| type_definition.ensure_type(id) }
+              read_before_type_cast.map { |id| type_definition.prepare(id) }
             end
           end
 

--- a/lib/granite/form/model/attributes/reference_one.rb
+++ b/lib/granite/form/model/attributes/reference_one.rb
@@ -24,7 +24,7 @@ module Granite
 
           def type_casted_value
             variable_cache(:value) do
-              type_definition.ensure_type(read_before_type_cast)
+              type_definition.prepare(read_before_type_cast)
             end
           end
 

--- a/lib/granite/form/model/attributes/reflections/attribute.rb
+++ b/lib/granite/form/model/attributes/reflections/attribute.rb
@@ -40,10 +40,6 @@ module Granite
               @defaultizer ||= options[:default]
             end
 
-            def enumerizer
-              @enumerizer ||= options[:enum] || options[:in]
-            end
-
             def normalizers
               @normalizers ||= Array.wrap(options[:normalize] || options[:normalizer] || options[:normalizers])
             end

--- a/lib/granite/form/model/attributes/reflections/base.rb
+++ b/lib/granite/form/model/attributes/reflections/base.rb
@@ -39,7 +39,11 @@ module Granite
             end
 
             def readonly
-              @readonly ||= options[:readonly]
+              options[:readonly]
+            end
+
+            def enum
+              options[:enum] || options[:in]
             end
 
             def inspect_reflection

--- a/lib/granite/form/model/attributes/represents.rb
+++ b/lib/granite/form/model/attributes/represents.rb
@@ -34,7 +34,7 @@ module Granite
             return unless reference.respond_to?(reader)
 
             variable_cache(:value) do
-              normalize(enumerize(type_definition.ensure_type(defaultize(reference.public_send(reader)))))
+              normalize(type_definition.prepare(defaultize(reference.public_send(reader))))
             end
           end
 

--- a/lib/granite/form/types/active_support/time_zone.rb
+++ b/lib/granite/form/types/active_support/time_zone.rb
@@ -5,6 +5,8 @@ module Granite
     module Types
       module ActiveSupport
         class TimeZone < Float
+        private
+
           def typecast(value)
             case value
             when ::ActiveSupport::TimeZone

--- a/lib/granite/form/types/array.rb
+++ b/lib/granite/form/types/array.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class Array < Object
+      private
+
         def typecast(value)
           if value.is_a?(::String)
             value.split(',').map(&:strip)

--- a/lib/granite/form/types/big_decimal.rb
+++ b/lib/granite/form/types/big_decimal.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class BigDecimal < Object
+      private
+
         def typecast(value)
           BigDecimal(Float(value).to_s) if value
         rescue ArgumentError, TypeError

--- a/lib/granite/form/types/boolean.rb
+++ b/lib/granite/form/types/boolean.rb
@@ -29,6 +29,8 @@ module Granite
           MAPPING[value]
         end
 
+      private
+
         def typecast(value)
           self.class.typecast(value)
         end

--- a/lib/granite/form/types/collection.rb
+++ b/lib/granite/form/types/collection.rb
@@ -9,11 +9,11 @@ module Granite
           @subtype_definition = subtype_definition
         end
 
-        def ensure_type(value)
+        def prepare(value)
           if value.respond_to? :transform_values
-            value.transform_values { |v| subtype_definition.ensure_type(v) }
+            value.transform_values { |v| subtype_definition.prepare(v) }
           elsif value.respond_to?(:map)
-            value.map { |v| subtype_definition.ensure_type(v) }
+            value.map { |v| subtype_definition.prepare(v) }
           end
         end
       end

--- a/lib/granite/form/types/date.rb
+++ b/lib/granite/form/types/date.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class Date < Object
+      private
+
         def typecast(value)
           value.try(:to_date)
         rescue ArgumentError

--- a/lib/granite/form/types/date_time.rb
+++ b/lib/granite/form/types/date_time.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class DateTime < Object
+      private
+
         def typecast(value)
           value.try(:to_datetime)
         rescue ArgumentError

--- a/lib/granite/form/types/float.rb
+++ b/lib/granite/form/types/float.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class Float < Object
+      private
+
         def typecast(value)
           Float(value)
         rescue ArgumentError, TypeError

--- a/lib/granite/form/types/hash_with_action_controller_parameters.rb
+++ b/lib/granite/form/types/hash_with_action_controller_parameters.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class HashWithActionControllerParameters < Object
+      private
+
         def typecast(value)
           case value
           when ActionController::Parameters

--- a/lib/granite/form/types/integer.rb
+++ b/lib/granite/form/types/integer.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class Integer < Float
+      private
+
         def typecast(value)
           super.try(:to_i)
         end

--- a/lib/granite/form/types/object.rb
+++ b/lib/granite/form/types/object.rb
@@ -13,6 +13,25 @@ module Granite
           @owner = owner
         end
 
+        def prepare(value)
+          enumerize(ensure_type(value))
+        end
+
+        def enum
+          source = owner.evaluate(reflection.enum)
+
+          case source
+          when ::Range
+            source.to_a
+          when ::Set
+            source
+          else
+            ::Array.wrap(source)
+          end.to_set
+        end
+
+      private
+
         def ensure_type(value)
           if value.instance_of?(type)
             value
@@ -23,6 +42,11 @@ module Granite
 
         def typecast(value)
           value if value.is_a?(type)
+        end
+
+        def enumerize(value)
+          set = enum if reflection.enum
+          value if !set || (set.none? || set.include?(value))
         end
       end
     end

--- a/lib/granite/form/types/string.rb
+++ b/lib/granite/form/types/string.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class String < Object
+      private
+
         def typecast(value)
           value.to_s
         end

--- a/lib/granite/form/types/time.rb
+++ b/lib/granite/form/types/time.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class Time < Object
+      private
+
         def typecast(value)
           value.is_a?(::String) && ::Time.zone ? ::Time.zone.parse(value) : value.try(:to_time)
         rescue ArgumentError

--- a/lib/granite/form/types/uuid.rb
+++ b/lib/granite/form/types/uuid.rb
@@ -4,6 +4,8 @@ module Granite
   module Form
     module Types
       class UUID < Object
+      private
+
         def typecast(value)
           case value
           when UUIDTools::UUID

--- a/spec/granite/form/model/attributes/attribute_spec.rb
+++ b/spec/granite/form/model/attributes/attribute_spec.rb
@@ -55,30 +55,6 @@ describe Granite::Form::Model::Attributes::Attribute do
     specify { expect(attribute(default: false, type: Boolean).defaultize(nil)).to eq(false) }
   end
 
-  describe '#enum' do
-    before { allow_any_instance_of(Dummy).to receive_messages(value: 1..5) }
-
-    specify { expect(attribute.enum).to eq([].to_set) }
-    specify { expect(attribute(enum: []).enum).to eq([].to_set) }
-    specify { expect(attribute(enum: 'hello').enum).to eq(['hello'].to_set) }
-    specify { expect(attribute(enum: %w[hello world]).enum).to eq(%w[hello world].to_set) }
-    specify { expect(attribute(enum: [1..5]).enum).to eq([1..5].to_set) }
-    specify { expect(attribute(enum: 1..5).enum).to eq((1..5).to_a.to_set) }
-    specify { expect(attribute(enum: -> { 1..5 }).enum).to eq((1..5).to_a.to_set) }
-    specify { expect(attribute(enum: -> { 'hello' }).enum).to eq(['hello'].to_set) }
-    specify { expect(attribute(enum: -> { ['hello', 42] }).enum).to eq(['hello', 42].to_set) }
-    specify { expect(attribute(enum: -> { value }).enum).to eq((1..5).to_a.to_set) }
-  end
-
-  describe '#enumerize' do
-    specify { expect(attribute.enumerize('anything')).to eq('anything') }
-    specify { expect(attribute(enum: ['hello', 42]).enumerize('hello')).to eq('hello') }
-    specify { expect(attribute(enum: ['hello', 42]).enumerize('world')).to eq(nil) }
-    specify { expect(attribute(enum: -> { 'hello' }).enumerize('hello')).to eq('hello') }
-    specify { expect(attribute(enum: -> { 1..5 }).enumerize(2)).to eq(2) }
-    specify { expect(attribute(enum: -> { 1..5 }).enumerize(42)).to eq(nil) }
-  end
-
   describe '#normalize' do
     specify { expect(attribute.normalize(' hello ')).to eq(' hello ') }
     specify { expect(attribute(normalizer: ->(v) { v.strip }).normalize(' hello ')).to eq('hello') }

--- a/spec/granite/form/model/attributes/reflections/attribute_spec.rb
+++ b/spec/granite/form/model/attributes/reflections/attribute_spec.rb
@@ -43,15 +43,6 @@ describe Granite::Form::Model::Attributes::Reflections::Attribute do
     specify { expect(reflection(default: -> {}).defaultizer).to be_a Proc }
   end
 
-  describe '#enumerizer' do
-    specify { expect(reflection.enumerizer).to be_nil }
-    specify { expect(reflection(enum: 42).enumerizer).to eq(42) }
-    specify { expect(reflection(enum: -> {}).enumerizer).to be_a Proc }
-    specify { expect(reflection(in: 42).enumerizer).to eq(42) }
-    specify { expect(reflection(in: -> {}).enumerizer).to be_a Proc }
-    specify { expect(reflection(enum: 42, in: -> {}).enumerizer).to eq(42) }
-  end
-
   describe '#normalizers' do
     specify { expect(reflection.normalizers).to eq([]) }
     specify { expect(reflection(normalizer: -> {}).normalizers).to be_a Array }

--- a/spec/granite/form/model/attributes/reflections/base_spec.rb
+++ b/spec/granite/form/model/attributes/reflections/base_spec.rb
@@ -44,4 +44,13 @@ describe Granite::Form::Model::Attributes::Reflections::Base do
     it { is_expected.to be_a(Granite::Form::Model::Attributes::Borogoves) }
     it { is_expected.to have_attributes(reflection: reflection, owner: owner, type: Object) }
   end
+
+  describe '#enum' do
+    specify { expect(reflection.enum).to be_nil }
+    specify { expect(reflection(enum: 42).enum).to eq(42) }
+    specify { expect(reflection(enum: -> {}).enum).to be_a Proc }
+    specify { expect(reflection(in: 42).enum).to eq(42) }
+    specify { expect(reflection(in: -> {}).enum).to be_a Proc }
+    specify { expect(reflection(enum: 42, in: -> {}).enum).to eq(42) }
+  end
 end

--- a/spec/granite/form/types/collection_spec.rb
+++ b/spec/granite/form/types/collection_spec.rb
@@ -2,13 +2,14 @@ require 'spec_helper'
 
 RSpec.describe Granite::Form::Types::Collection do
   subject { described_class.new(subtype_definition) }
-  let(:subtype_definition) { Granite::Form::Types::Object.new(Dummy, nil, nil) }
+  let(:subtype_definition) { Granite::Form::Types::Object.new(Dummy, reflection, nil) }
+  let(:reflection) { Granite::Form::Model::Attributes::Reflections::Base.new(:field) }
   let(:dummy_object) { Dummy.new }
 
   before { stub_class :dummy }
 
-  describe '#ensure_type' do
-    specify { expect(subject.ensure_type([dummy_object, Object.new])).to eq([dummy_object, nil]) }
-    specify { expect(subject.ensure_type(one: dummy_object, two: Object.new)).to eq(one: dummy_object, two: nil) }
+  describe '#prepare' do
+    specify { expect(subject.prepare([dummy_object, Object.new])).to eq([dummy_object, nil]) }
+    specify { expect(subject.prepare(one: dummy_object, two: Object.new)).to eq(one: dummy_object, two: nil) }
   end
 end

--- a/spec/granite/form/types/object_spec.rb
+++ b/spec/granite/form/types/object_spec.rb
@@ -3,12 +3,24 @@
 require 'spec_helper'
 
 RSpec.describe Granite::Form::Types::Object do
-  subject(:type) { described_class.new(String, reflection, model.new) }
-  let(:model) { stub_model }
-  let(:reflection) { Granite::Form::Model::Attributes::Reflections::Base.new(:field) }
+  subject(:type) { build_type(reflection: reflection) }
+  let(:model) { Model.new }
+  let(:reflection) { build_reflection }
+
+  before do
+    stub_model :model
+  end
+
+  def build_reflection(name: :field, **options)
+    Granite::Form::Model::Attributes::Reflections::Base.new(name, options)
+  end
+
+  def build_type(type: String, reflection: nil, **options)
+    described_class.new(type, reflection || build_reflection(**options), model)
+  end
 
   describe '#initialize' do
-    it { is_expected.to have_attributes(type: String, reflection: reflection, owner: an_instance_of(model)) }
+    it { is_expected.to have_attributes(type: String, reflection: reflection, owner: model) }
   end
 
   describe 'typecasting' do
@@ -36,5 +48,31 @@ RSpec.describe Granite::Form::Types::Object do
       specify { expect(typecast(Object.new)).to be_nil }
       specify { expect(typecast(nil)).to be_nil }
     end
+  end
+
+  describe '#enum' do
+    before { allow(model).to receive_messages(value: 1..5) }
+
+    specify { expect(build_type.enum).to eq([].to_set) }
+    specify { expect(build_type(enum: []).enum).to eq([].to_set) }
+    specify { expect(build_type(enum: 'hello').enum).to eq(['hello'].to_set) }
+    specify { expect(build_type(enum: %w[hello world]).enum).to eq(%w[hello world].to_set) }
+    specify { expect(build_type(enum: [1..5]).enum).to eq([1..5].to_set) }
+    specify { expect(build_type(enum: 1..5).enum).to eq((1..5).to_a.to_set) }
+    specify { expect(build_type(enum: -> { 1..5 }).enum).to eq((1..5).to_a.to_set) }
+    specify { expect(build_type(enum: -> { 'hello' }).enum).to eq(['hello'].to_set) }
+    specify { expect(build_type(enum: -> { ['hello', 42] }).enum).to eq(['hello', 42].to_set) }
+    specify { expect(build_type(enum: -> { value }).enum).to eq((1..5).to_a.to_set) }
+  end
+
+  describe '#prepare' do
+    specify { expect(build_type.prepare('anything')).to eq('anything') }
+    specify { expect(build_type(enum: %w[hello 42]).prepare('hello')).to eq('hello') }
+    specify { expect(build_type(enum: %w[hello 42]).prepare('world')).to eq(nil) }
+    specify { expect(build_type(enum: %w[hello 42]).prepare('42')).to eq('42') }
+    specify { expect(build_type(enum: %w[hello 42]).prepare(42)).to eq(nil) }
+    specify { expect(build_type(enum: -> { 'hello' }).prepare('hello')).to eq('hello') }
+    specify { expect(build_type(type: Integer, enum: -> { 1..5 }).prepare(2)).to eq(2) }
+    specify { expect(build_type(type: Integer, enum: -> { 1..5 }).prepare(42)).to eq(nil) }
   end
 end


### PR DESCRIPTION
Currently enumerization is taken care of by `Attribute` but I believe it should be handled by `type_definition`. 

The reason mostly becomes clear when you think about something like `collection :statuses, String, enum: %w[created deleted]`. The question is how this should be interpreted? Does this mean that `statuses` itself can only equal `'created'` or `'deleted'` OR that each element in `statuses` can only equal `'created'` or `'deleted'`? 

To me it sounds like we're talking about the second case, so that means that `enum` is part of type definition, as it doesn't depend on whether the attribute is a collection or a single entity. In a sense using enum we create a subtype (of string in this case), which only allows limited values.

Compare that to for example `default`, `collection :statuses, String, default: %w[created deleted]`. In this case I'd say developer is expecting to have `%w[created deleted]` in `statuses` by default and not have `%w[created deleted]` in each element of `statuses`, which doesn't even make sense since presumably `statuses` was never set to begin with, so we don't know how many elements we should have. This BTW is not how currently `default` works, but one problem at a time.

* Extracts enum & enumerize to type definition.
* Introduce `Types::Object#prepare` which typecasts and the enumerizes the value.
* Move `Attributes::Reflections::Attribute#enumerizer` to `Attributes::Reflections::Base` and replace it to `enum` for consistency with type_definition and attribute itself.