### PR TITLE
Use node16 for gha

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,7 +36,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
@@ -46,7 +46,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.0'


### PR DESCRIPTION
[DEVX-1793](https://toptal-core.atlassian.net/browse/DEVX-1793)

### Description
Github actions in some few months would stop support for node12 as well as supporting `set-state` and `set-output` command via `stdout`. This is to update those workflows to fix those deprecations.

[DEVX-1793]: https://toptal-core.atlassian.net/browse/DEVX-1793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ