### PR TITLE
Fix deprecated #to_s method

### DIFF
--- a/lib/granite/form/model/attributes/base.rb
+++ b/lib/granite/form/model/attributes/base.rb
@@ -58,7 +58,7 @@ module Granite
           def inspect_attribute
             value = case read
             when Date, Time, DateTime
-              %("#{read.to_s(:db)}")
+              %("#{read.to_formatted_s(:db)}")
             else
               inspection = read.inspect
               inspection.size > 100 ? inspection.truncate(50) : inspection

--- a/spec/granite/form/model/attributes/base_spec.rb
+++ b/spec/granite/form/model/attributes/base_spec.rb
@@ -103,4 +103,22 @@ describe Granite::Form::Model::Attributes::Base do
 
     it { is_expected.to have_attributes(type: String, reflection: subject.reflection, owner: model) }
   end
+
+  describe '#inspect_attribute' do
+    let(:field) { attribute(type: type) }
+    let(:object) { Object.new }
+
+    {
+      'hello' => 'field: "hello"',
+      123 => 'field: 123',
+      Date.new(2023, 6, 20) => 'field: "2023-06-20"',
+      DateTime.new(2023, 6, 20, 12, 30) => 'field: "2023-06-20 12:30:00"', # rubocop:disable Style/DateTime
+      Time.new(2023, 6, 20, 12, 30) => 'field: "2023-06-20 12:30:00"'
+    }.each do |input, expected_output|
+      context "attribute type is #{input.class}" do
+        let(:type) { input.class }
+        specify { expect(field.tap { |r| r.write(input) }.inspect_attribute).to eq(expected_output) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Replaces `#to_s(:db)` method with a new `#to_fs(:db)` method.
It is implemented by ActiveSupport for Date, Time and DateTime classes.
`#to_s` got deprecated with Rails 7.0.0.

It effects with the reason of failed specs being hidden behind an error message related to this deprecation, as below:
```
     Failure/Error: expect(@target).to expectation

     ActiveSupport::DeprecationException:
       DEPRECATION WARNING: Date#to_s(:db) is deprecated. Please use Date#to_fs(:db) instead. (called from inspect_attribute at /Users/maciej/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/bundler/gems/granite-form-8f25486a2155/lib/granite/form/model/attributes/base.rb:61)
```