### PR TITLE
[PSRE-4136] Lower severity of the log messasge during mass assignment

### DIFF
--- a/lib/granite/form/model/attributes.rb
+++ b/lib/granite/form/model/attributes.rb
@@ -172,7 +172,7 @@ module Granite
             if respond_to?("#{name}=") && !sanitize_value
               public_send("#{name}=", value)
             else
-              logger.info("Ignoring #{sanitize_value ? 'primary' : 'undefined'} `#{name}` attribute value for #{self} during mass-assignment")
+              logger.debug("Ignoring #{sanitize_value ? 'primary' : 'undefined'} `#{name}` attribute value for #{self} during mass-assignment")
             end
           end
         end


### PR DESCRIPTION
Lower down severity level for the mass assignment notification, since it generates a lot of issues for us.