### PR TITLE
Rework dynamic methods for better performance

### DIFF
--- a/lib/granite/form/model/associations/reflections/base.rb
+++ b/lib/granite/form/model/associations/reflections/base.rb
@@ -23,15 +23,13 @@ module Granite
             end
 
             def self.generate_methods(name, target)
-              target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{name} force_reload = false
-                association(:#{name}).reader(force_reload)
+              target.define_method(name) do |force_reload = false|
+                association(name.to_sym).reader(force_reload)
               end
 
-              def #{name}= value
-                association(:#{name}).writer(value)
+              target.define_method("#{name}=") do |value|
+                association(name.to_sym).writer(value)
               end
-              RUBY
             end
 
             def self.association_class

--- a/lib/granite/form/model/associations/reflections/embeds_one.rb
+++ b/lib/granite/form/model/associations/reflections/embeds_one.rb
@@ -15,11 +15,9 @@ module Granite
             def self.generate_methods(name, target)
               super
 
-              target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def build_#{name} attributes = {}
-                  association(:#{name}).build(attributes)
-                end
-              RUBY
+              target.define_method("build_#{name}") do |attributes = {}|
+                association(name.to_sym).build(attributes)
+              end
             end
           end
         end

--- a/lib/granite/form/model/attributes/reflections/attribute.rb
+++ b/lib/granite/form/model/attributes/reflections/attribute.rb
@@ -9,35 +9,33 @@ module Granite
             end
 
             def self.generate_methods(name, target)
-              target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{name}
-                attribute('#{name}').read
+              target.define_method(name) do
+                attribute(name).read
               end
 
-              def #{name}= value
-                attribute('#{name}').write(value)
+              target.define_method("#{name}=") do |value|
+                attribute(name).write(value)
               end
 
-              def #{name}?
-                attribute('#{name}').query
+              target.define_method("#{name}?") do
+                attribute(name).query
               end
 
-              def #{name}_before_type_cast
-                attribute('#{name}').read_before_type_cast
+              target.define_method("#{name}_before_type_cast") do
+                attribute(name).read_before_type_cast
               end
 
-              def #{name}_came_from_user?
-                attribute('#{name}').came_from_user?
+              target.define_method("#{name}_came_from_user?") do
+                attribute(name).came_from_user?
               end
 
-              def #{name}_default
-                attribute('#{name}').default
+              target.define_method("#{name}_default") do
+                attribute(name).default
               end
 
-              def #{name}_values
-                attribute('#{name}').enum.to_a
+              target.define_method("#{name}_values") do
+                attribute(name).enum.to_a
               end
-              RUBY
             end
 
             def defaultizer

--- a/lib/granite/form/model/attributes/reflections/reference_one.rb
+++ b/lib/granite/form/model/attributes/reflections/reference_one.rb
@@ -5,23 +5,21 @@ module Granite
         module Reflections
           class ReferenceOne < Base
             def self.generate_methods(name, target)
-              target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{name}
-                attribute('#{name}').read
+              target.define_method(name) do
+                attribute(name).read
               end
 
-              def #{name}= value
-                attribute('#{name}').write(value)
+              target.define_method("#{name}=") do |value|
+                attribute(name).write(value)
               end
 
-              def #{name}?
-                attribute('#{name}').query
+              target.define_method("#{name}?") do
+                attribute(name).query
               end
 
-              def #{name}_before_type_cast
-                attribute('#{name}').read_before_type_cast
+              target.define_method("#{name}_before_type_cast") do
+                attribute(name).read_before_type_cast
               end
-              RUBY
             end
 
             def inspect_reflection

--- a/lib/granite/form/model/dirty.rb
+++ b/lib/granite/form/model/dirty.rb
@@ -60,18 +60,14 @@ module Granite
 
             %w[changed? change will_change! was
                previously_changed? previous_change].each do |suffix|
-              target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def #{method}_#{suffix}
-                attribute_#{suffix} '#{name}'
-              end
-              RUBY
+              target.define_method("#{method}_#{suffix}") do
+                  __send__(:"attribute_#{suffix}", name)
+                end
             end
 
-            target.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def restore_#{method}!
-              restore_attribute! '#{name}'
-            end
-            RUBY
+            target.define_method("restore_#{method}!") do
+                restore_attribute!(name)
+              end
           end
 
           def dirty?


### PR DESCRIPTION
Defining methods with `define_method` seems to be much more performant than `class_eval`. Although it is more risky as it might store unwonted variables in block bindings.
