### PR TITLE
[DEVX-3814] Fix crash when mapping PostgreSQL enum to ruby variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* Fix crash when mapping PostgreSQL enum to ruby variable in https://github.com/toptal/granite-form/pull/28
+
 ## v0.5.0
 
 * Support for ruby 3.2 by @konalegi in https://github.com/toptal/granite-form/pull/22
@@ -15,7 +17,7 @@
 * Add support for evaluating `Symbol` for readonly/enum/normalize. If symbol is passed in one of those options, method with that name will be called when evaluating the value.
 * [BREAKING] Remove `localized` attribute type.
 * [BREAKING] Change the behavior of `default` and `normalize` for `collection` & `dictionary`. Instead of acting per element they will now act on the attribute as a whole.
-  * E.g. `collection :numbers, default: [1, 2, 3]` will not set the default for the whole collection of `numbers` rather than each element in `numbers`. 
+  * E.g. `collection :numbers, default: [1, 2, 3]` will not set the default for the whole collection of `numbers` rather than each element in `numbers`.
 
 ## v0.3.0
 
@@ -32,7 +34,7 @@
 
 ## v0.1.1
 
-- Fixed represented error message copying when represented model uses symbols for `message`. 
+- Fixed represented error message copying when represented model uses symbols for `message`.
 
 ## v0.1.0
 

--- a/lib/granite/form/model/associations/persistence_adapters/active_record.rb
+++ b/lib/granite/form/model/associations/persistence_adapters/active_record.rb
@@ -17,7 +17,8 @@ module Granite
               text: String,
               string: String,
               binary: String,
-              boolean: Boolean
+              boolean: Boolean,
+              enum: String
             }.freeze
 
             alias_method :data_type, :data_source

--- a/spec/granite/form/model/representation_spec.rb
+++ b/spec/granite/form/model/representation_spec.rb
@@ -11,12 +11,15 @@ describe Granite::Form::Model::Representation do
         include Granite::Form::Model::Representation
 
         attribute :author, Object
+        attribute :foo_container, Object
         alias_attribute :a, :author
         represents :rate, of: :a
+        represents :foos, of: :foo_container
         alias_attribute :r, :rate
       end
     end
     let(:author) { Author.new(rate: '42') }
+    let(:foos) { %w[foo bar] }
 
     specify { expect(Post.reflect_on_attribute(:rate).reference).to eq('author') }
 
@@ -29,6 +32,10 @@ describe Granite::Form::Model::Representation do
 
     specify { expect(Post.new.rate).to be_nil }
     specify { expect(Post.new.rate_before_type_cast).to be_nil }
+
+    if ActiveModel.version >= Gem::Version.new('7.0.0') # rubocop:disable Style/IfUnlessModifier
+      specify { expect { Post.new(foo_container: FooContainer.new, foos: foos) }.not_to raise_exception }
+    end
 
     context 'ActionController::Parameters' do
       let(:params) { instance_double('ActionController::Parameters', to_unsafe_hash: {rate: '33', author: author}) }

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -20,4 +20,17 @@ ActiveRecord::Schema.define do
     t.column :related_ids, :integer, array: true
     t.column :data, :text
   end
+
+  if ActiveModel.version >= Gem::Version.new('7.0.0')
+    create_enum 'foo', %w[foo bar baz]
+
+    create_table :foo_containers, force: :cascade do |t|
+      t.enum :foos, enum_type: 'foo', array: true
+    end
+  end
+end
+
+if ActiveModel.version >= Gem::Version.new('7.0.0')
+  class FooContainer < ActiveRecord::Base
+  end
 end


### PR DESCRIPTION
## Description

`granite-form` takes it on itself to do data mapping when it's setup with `represents`. 
There is a big configuration file, and that file did not support `enum` transformation. I added configuration which maps `enum` variable to strings, which should resolve the issue.

