### PR TITLE
Attributes.mass_assignment_strict_mode

### DIFF
--- a/lib/granite/form/model/attributes.rb
+++ b/lib/granite/form/model/attributes.rb
@@ -16,10 +16,13 @@ module Granite
         extend ActiveSupport::Concern
 
         included do
-          class_attribute :_attributes, :_attribute_aliases, :_sanitize, instance_reader: false, instance_writer: false
+          class_attribute :_attributes, :_attribute_aliases, :_sanitize,
+                          :mass_assignment_strict_mode,
+                          instance_reader: false, instance_writer: false
           self._attributes = {}
           self._attribute_aliases = {}
           self._sanitize = true
+          self.mass_assignment_strict_mode = false
 
           delegate :attribute_names, :has_attribute?, to: 'self.class'
 
@@ -209,7 +212,11 @@ module Granite
         private
 
         def report_unknown_attribute(attribute_type, name)
-          logger.debug("Ignoring #{attribute_type} `#{name}` attribute value for #{self} during mass-assignment")
+          if self.class.mass_assignment_strict_mode
+            raise ActiveModel::UnknownAttributeError.new(self, name.to_s)
+          else
+            logger.debug("Ignoring #{attribute_type} `#{name}` attribute value for #{self} during mass-assignment")
+          end
         end
 
         def attributes_for_inspect

--- a/lib/granite/form/model/attributes.rb
+++ b/lib/granite/form/model/attributes.rb
@@ -212,11 +212,9 @@ module Granite
         private
 
         def report_unknown_attribute(attribute_type, name)
-          if self.class.mass_assignment_strict_mode
-            raise ActiveModel::UnknownAttributeError.new(self, name.to_s)
-          else
-            logger.debug("Ignoring #{attribute_type} `#{name}` attribute value for #{self} during mass-assignment")
-          end
+          raise ActiveModel::UnknownAttributeError.new(self, name.to_s) if self.class.mass_assignment_strict_mode
+
+          logger.debug("Ignoring #{attribute_type} `#{name}` attribute value for #{self} during mass-assignment")
         end
 
         def attributes_for_inspect

--- a/lib/granite/form/model/attributes.rb
+++ b/lib/granite/form/model/attributes.rb
@@ -180,7 +180,7 @@ module Granite
               public_send("#{name}=", value)
             else
               attribute_type = sanitize_value ? 'primary' : 'undefined'
-              logger.debug("Ignoring #{attribute_type} `#{name}` attribute value for #{self} during mass-assignment")
+              report_unknown_attribute(attribute_type, name)
             end
           end
         end
@@ -207,6 +207,10 @@ module Granite
         end
 
         private
+
+        def report_unknown_attribute(attribute_type, name)
+          logger.debug("Ignoring #{attribute_type} `#{name}` attribute value for #{self} during mass-assignment")
+        end
 
         def attributes_for_inspect
           attribute_names(false).map do |name|

--- a/spec/granite/form/model/attributes_spec.rb
+++ b/spec/granite/form/model/attributes_spec.rb
@@ -206,6 +206,27 @@ describe Granite::Form::Model::Attributes do
         end
       end
     end
+
+    context 'with mass_assignment_strict_mode' do
+      let(:model) do
+        stub_model do
+          self.mass_assignment_strict_mode = true
+          attribute :full_name, String
+          alias_attribute :name, :full_name
+        end
+      end
+
+      specify do
+        expect do
+          subject.assign_attributes(name: 'name', unexisting: 'value')
+        end.to raise_error(ActiveModel::UnknownAttributeError, /unknown attribute 'unexisting' for/)
+      end
+
+      specify do
+        subject.assign_attributes(name: 'name', full_name: 'full_name')
+        expect(subject.name).to eq('full_name')
+      end
+    end
   end
 
   describe '#sync_attributes' do


### PR DESCRIPTION
Implements mass_assignment_strict_mode

The setting is per class and configures strict handling of unknown attributes by raising an exception, just like Rails/ActiveModel does.
    
By default it is disabled, and you need to opt-in.
    
This is valuable for cases where Granite is used in combination with GQL mutations and there is no risk of using incorrect attributes or getting some accidental _junk_ from web forms.